### PR TITLE
Add full-width cover image option to hero block

### DIFF
--- a/src/blocks/hero/block.json
+++ b/src/blocks/hero/block.json
@@ -4,19 +4,21 @@
   "title": "LBJ - Hero",
   "category": "design",
   "icon": "format-image",
-  "description": "Hero with background image, overlay, title & subtitle.",
+  "description": "Hero with full-width cover image, overlay, title & subtitle.",
   "textdomain": "luxurybazaar_jewelry",
   "attributes": {
     "title": { "type": "string", "default": "Your Hero Title" },
     "subtitle": { "type": "string", "default": "A short supporting subtitle goes here." },
-    "mediaURL": { "type": "string", "default": "" },
+    "coverURL": { "type": "string", "default": "" },
     "overlayOpacity": { "type": "number", "default": 0.35 },
-    "minHeight": { "type": "number", "default": 420 }
+    "minHeight": { "type": "number", "default": 420 },
+    "align": { "type": "string", "default": "full" }
   },
   "supports": {
     "html": false,
     "spacing": { "padding": true, "margin": true },
-    "color": { "text": true }
+    "color": { "text": true },
+    "align": ["full"]
   },
   "editorScript": "file:./index.js",
   "style": "file:./style.css",

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -7,19 +7,19 @@ import './editor.css';
 
 registerBlockType('lb-jewelry/hero', {
   edit: ({ attributes, setAttributes }) => {
-    const { title, subtitle, mediaURL, overlayOpacity, minHeight } = attributes;
+    const { title, subtitle, coverURL, overlayOpacity, minHeight } = attributes;
     const blockProps = useBlockProps({ className: 'wpgcb-hero' });
 
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('Background', 'luxurybazaar_jewelry')} initialOpen={true}>
+          <PanelBody title={__('Cover Image', 'luxurybazaar_jewelry')} initialOpen={true}>
             <MediaUpload
-              onSelect={(media) => setAttributes({ mediaURL: media.url })}
+              onSelect={(media) => setAttributes({ coverURL: media.url })}
               allowedTypes={['image']}
               render={({ open }) => (
                 <Button variant="primary" onClick={open}>
-                  { mediaURL ? __('Change image', 'luxurybazaar_jewelry') : __('Choose image', 'luxurybazaar_jewelry') }
+                  { coverURL ? __('Change cover', 'luxurybazaar_jewelry') : __('Choose cover', 'luxurybazaar_jewelry') }
                 </Button>
               )}
             />
@@ -42,7 +42,7 @@ registerBlockType('lb-jewelry/hero', {
           </PanelBody>
         </InspectorControls>
         <div {...blockProps} style={{ minHeight: minHeight + 'px' }}>
-          {mediaURL && <div className="wpgcb-hero__bg" style={{ backgroundImage: `url(${mediaURL})` }} />}
+          {coverURL && <div className="wpgcb-hero__cover" style={{ backgroundImage: `url(${coverURL})` }} />}
           <div className="wpgcb-hero__overlay" style={{ opacity: overlayOpacity }} />
           <div className="wpgcb-hero__content">
             <RichText
@@ -65,11 +65,11 @@ registerBlockType('lb-jewelry/hero', {
     );
   },
   save: ({ attributes }) => {
-    const { title, subtitle, mediaURL, overlayOpacity, minHeight } = attributes;
+    const { title, subtitle, coverURL, overlayOpacity, minHeight } = attributes;
     const blockProps = useBlockProps.save({ className: 'wpgcb-hero', style: { minHeight: minHeight + 'px' } });
     return (
       <div {...blockProps}>
-        {mediaURL && <div className="wpgcb-hero__bg" style={{ backgroundImage: `url(${mediaURL})` }} />}
+        {coverURL && <div className="wpgcb-hero__cover" style={{ backgroundImage: `url(${coverURL})` }} />}
         <div className="wpgcb-hero__overlay" style={{ opacity: overlayOpacity }} />
         <div className="wpgcb-hero__content">
           <RichText.Content tagName="h1" className="wpgcb-hero__title" value={title} />

--- a/src/blocks/hero/style.css
+++ b/src/blocks/hero/style.css
@@ -1,5 +1,5 @@
-.wpgcb-hero { position:relative; display:grid; place-items:center; text-align:center; color:var(--wp--preset--color--base,#fff); padding:var(--wp--preset--spacing--30,2rem); overflow:hidden; }
-.wpgcb-hero__bg { position:absolute; inset:0; background-size:cover; background-position:center; z-index:0; filter:saturate(1.05); }
+.wpgcb-hero { position:relative; display:grid; place-items:center; text-align:center; color:var(--wp--preset--color--base,#fff); padding:var(--wp--preset--spacing--30,2rem); overflow:hidden; width:100%; }
+.wpgcb-hero__cover { position:absolute; inset:0; background-size:cover; background-position:center; z-index:0; filter:saturate(1.05); }
 .wpgcb-hero__overlay { position:absolute; inset:0; background:#000; z-index:1; }
 .wpgcb-hero__content { position:relative; z-index:2; max-width:900px; }
 .wpgcb-hero__title { margin:0 0 .5rem; font-size:clamp(2rem,4vw,3rem); }


### PR DESCRIPTION
## Summary
- allow hero block to select a cover image
- default hero block to full-width alignment
- update hero styles for cover image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c96a0cfd483268984ac6465be1ed8