### PR TITLE
Add dynamic product carousel block

### DIFF
--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -1,19 +1,28 @@
 {
   "apiVersion": 2,
   "name": "lb-jewelry/carousel",
-  "title": "LBJ - Carousel (Swiper)",
-  "category": "media",
+  "title": "LBJ - Product Carousel",
+  "category": "widgets",
   "icon": "images-alt2",
-  "description": "Image carousel using Swiper with pagination and arrows.",
+  "description": "Carousel showing latest jewelry products.",
   "textdomain": "luxurybazaar_jewelry",
   "attributes": {
-    "slides": {
-      "type": "array",
-      "default": [],
-      "items": { "type": "object" }
+    "title": {
+      "type": "string",
+      "default": ""
+    },
+    "productsToShow": {
+      "type": "number",
+      "default": 6
+    },
+    "preview": {
+      "type": "boolean",
+      "default": false
     }
   },
   "supports": { "html": false },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css"
+  "style": "file:./style.css",
+  "render": "file:./render.php"
 }
+

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -1,83 +1,42 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { MediaUpload, MediaUploadCheck, RichText, useBlockProps } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import { InspectorControls, RichText, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
 import './style.css';
 
 registerBlockType('lb-jewelry/carousel', {
   edit: ({ attributes, setAttributes }) => {
-    const { slides = [] } = attributes;
-    const blockProps = useBlockProps({ className: 'wpgcb-carousel' });
-
-    const addSlide = (media) => {
-      const next = [ ...slides, { url: media.url, alt: media.alt || '', caption: '' } ];
-      setAttributes({ slides: next });
-    };
-
-    const updateCaption = (i, caption) => {
-      const next = slides.map((s, idx) => idx === i ? { ...s, caption } : s);
-      setAttributes({ slides: next });
-    };
-
-    const removeSlide = (i) => {
-      const next = slides.filter((_, idx) => idx !== i);
-      setAttributes({ slides: next });
-    };
-
+    const { title, productsToShow } = attributes;
+    const blockProps = useBlockProps({ className: 'lbj-product-carousel' });
     return (
-      <div {...blockProps}>
-        <div className="wpgcb-carousel__controls">
-          <MediaUploadCheck>
-            <MediaUpload
-              onSelect={addSlide}
-              allowedTypes={['image']}
-              multiple={false}
-              render={({ open }) => (
-                <Button variant="primary" onClick={open}>
-                  {__('Add image', 'luxurybazaar_jewelry')}
-                </Button>
-              )}
+      <>
+        <InspectorControls>
+          <PanelBody title={__('Carousel Settings', 'luxurybazaar_jewelry')} initialOpen={true}>
+            <RangeControl
+              label={__('Number of products', 'luxurybazaar_jewelry')}
+              value={productsToShow}
+              onChange={(v) => setAttributes({ productsToShow: v })}
+              min={1}
+              max={12}
             />
-          </MediaUploadCheck>
+          </PanelBody>
+        </InspectorControls>
+        <div {...blockProps}>
+          <RichText
+            tagName="h2"
+            className="lbj-carousel__title"
+            value={title}
+            onChange={(v) => setAttributes({ title: v })}
+            placeholder={__('Add title…', 'luxurybazaar_jewelry')}
+          />
+          <ServerSideRender
+            block="lb-jewelry/carousel"
+            attributes={{ ...attributes, preview: true }}
+          />
         </div>
-        <div className="wpgcb-carousel__editor-list">
-          {slides.length === 0 && <p>{__('No slides yet. Use “Add image”.', 'luxurybazaar_jewelry')}</p>}
-          {slides.map((s, i) => (
-            <div key={i} className="wpgcb-carousel__editor-item">
-              <img src={s.url} alt={s.alt || ''} />
-              <RichText
-                tagName="p"
-                className="wpgcb-carousel__caption"
-                value={s.caption}
-                onChange={(v) => updateCaption(i, v)}
-                placeholder={__('Add caption…', 'luxurybazaar_jewelry')}
-              />
-              <Button variant="secondary" onClick={() => removeSlide(i)}>{__('Remove', 'luxurybazaar_jewelry')}</Button>
-            </div>
-          ))}
-        </div>
-      </div>
+      </>
     );
   },
-  save: ({ attributes }) => {
-    const { slides = [] } = attributes;
-    const blockProps = useBlockProps.save({ className: 'wpgcb-carousel lbj-carousel' });
-    return (
-      <div {...blockProps}>
-        <div className="swiper">
-          <div className="swiper-wrapper">
-            {slides.map((s, i) => (
-              <div key={i} className="swiper-slide">
-                <img src={s.url} alt={s.alt || ''} />
-                {s.caption && <p className="wpgcb-carousel__caption">{s.caption}</p>}
-              </div>
-            ))}
-          </div>
-          <div className="swiper-pagination"></div>
-          <div className="swiper-button-prev"></div>
-          <div className="swiper-button-next"></div>
-        </div>
-      </div>
-    );
-  }
+  save: () => null,
 });

--- a/src/blocks/carousel/render.php
+++ b/src/blocks/carousel/render.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Render callback for product carousel block.
+ *
+ * @param array $attributes Block attributes.
+ * @return string HTML.
+ */
+return function( $attributes ) {
+    $title   = isset( $attributes['title'] ) ? $attributes['title'] : '';
+    $count   = isset( $attributes['productsToShow'] ) ? intval( $attributes['productsToShow'] ) : 6;
+    $preview = ! empty( $attributes['preview'] );
+
+    if ( ! function_exists( 'wc_get_products' ) ) {
+        return '';
+    }
+
+    $products = wc_get_products(
+        array(
+            'status'   => 'publish',
+            'limit'    => $count,
+            'orderby'  => 'date',
+            'order'    => 'DESC',
+            'category' => array( 'jewelry' ),
+        )
+    );
+
+    if ( empty( $products ) ) {
+        return $preview ? '<p>' . esc_html__( 'No jewelry products found.', 'luxurybazaar_jewelry' ) . '</p>' : '';
+    }
+
+    ob_start();
+    ?>
+    <div class="lbj-carousel-block">
+        <?php if ( $title && ! $preview ) : ?>
+            <h2 class="lbj-carousel__title"><?php echo esc_html( $title ); ?></h2>
+        <?php endif; ?>
+        <div class="wpgcb-carousel lbj-carousel">
+            <div class="swiper">
+                <div class="swiper-wrapper">
+                    <?php foreach ( $products as $product ) : ?>
+                        <div class="swiper-slide">
+                            <a href="<?php echo esc_url( get_permalink( $product->get_id() ) ); ?>">
+                                <?php echo $product->get_image( 'medium' ); ?>
+                                <p class="wpgcb-carousel__caption"><?php echo esc_html( $product->get_name() ); ?></p>
+                            </a>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <div class="swiper-pagination"></div>
+                <div class="swiper-button-prev"></div>
+                <div class="swiper-button-next"></div>
+            </div>
+        </div>
+    </div>
+    <?php
+    return ob_get_clean();
+};
+

--- a/src/blocks/carousel/style.css
+++ b/src/blocks/carousel/style.css
@@ -2,7 +2,3 @@
 .wpgcb-carousel .swiper-slide { display:grid; justify-items:center; gap:.5rem; }
 .wpgcb-carousel img { width:100%; height:auto; border-radius:12px; display:block; }
 .wpgcb-carousel__caption { margin:.25rem 0 0; font-size:.95rem; opacity:.9; text-align:center; }
-.wpgcb-carousel__controls { margin-bottom:.75rem; }
-.wpgcb-carousel__editor-list { display:grid; grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); gap:.75rem; }
-.wpgcb-carousel__editor-item { border:1px solid #e3e3e3; border-radius:8px; padding:.5rem; background:#fff; }
-.wpgcb-carousel__editor-item img { width:100%; height:auto; border-radius:6px; }


### PR DESCRIPTION
## Summary
- replace static image carousel with dynamic product carousel block
- allow editors to set carousel title and number of items
- render latest `jewelry` products server-side and initialize Swiper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c9c5691ec8326a0c8eeff8b8b262f