### PR TITLE
Fix block CSS enqueue references

### DIFF
--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -22,7 +22,7 @@
   },
   "supports": { "html": false },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css",
+  "style": "file:./style-index.css",
   "render": "file:./render.php"
 }
 

--- a/src/blocks/cta/block.json
+++ b/src/blocks/cta/block.json
@@ -19,5 +19,5 @@
     "align": { "type": "string", "default": "wide" }
   },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css"
+  "style": "file:./style-index.css"
 }

--- a/src/blocks/hero/block.json
+++ b/src/blocks/hero/block.json
@@ -21,6 +21,6 @@
     "align": ["full"]
   },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css",
-  "editorStyle": "file:./editor.css"
+  "style": "file:./style-index.css",
+  "editorStyle": "file:./index.css"
 }

--- a/src/blocks/simple-section/block.json
+++ b/src/blocks/simple-section/block.json
@@ -17,6 +17,6 @@
     "align": { "type": "string", "default": "full" }
   },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css",
-  "editorStyle": "file:./editor.css"
+  "style": "file:./style-index.css",
+  "editorStyle": "file:./index.css"
 }


### PR DESCRIPTION
## Summary
- reference built style-index.css and index.css files in block metadata so WordPress enqueues front-end and editor CSS correctly

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689cb46d6a0083269fa166b8484cc2f1