### PR TITLE
feat: stretch hero to full viewport

### DIFF
--- a/src/blocks/hero/style.css
+++ b/src/blocks/hero/style.css
@@ -1,4 +1,4 @@
-.wpgcb-hero { position:relative; display:flex; flex-direction:column; justify-content:flex-end; text-align:center; color:#fff; padding:2rem; padding-bottom:calc(2rem + 100px); overflow:hidden; width:100%; }
+.wpgcb-hero { position:relative; display:flex; flex-direction:column; justify-content:flex-end; text-align:center; color:#fff; padding:2rem; padding-bottom:calc(2rem + 100px); overflow:hidden; width:100%; min-height:100vh; }
 .wpgcb-hero__cover { position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0; filter:saturate(1.05); }
 .wpgcb-hero__overlay { position:absolute; inset:0; background:#000; z-index:1; }
 .wpgcb-hero__rect { position:absolute; bottom:0; width:180px; height:100px; background:rgba(255,255,255,.3); z-index:2; }


### PR DESCRIPTION
## Summary
- stretch hero section to cover full viewport height

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbdd452b083269944351e3d45809e