### PR TITLE
fix: stretch hero to full viewport

### DIFF
--- a/src/blocks/hero/block.json
+++ b/src/blocks/hero/block.json
@@ -11,14 +11,14 @@
     "subtitle": { "type": "string", "default": "A short supporting subtitle goes here." },
     "coverURL": { "type": "string", "default": "" },
     "overlayOpacity": { "type": "number", "default": 0.35 },
-    "minHeight": { "type": "number", "default": 420 },
     "align": { "type": "string", "default": "full" }
   },
   "supports": {
     "html": false,
     "spacing": { "padding": true, "margin": true },
     "color": { "text": true },
-    "align": ["full"]
+    "align": ["full"],
+    "dimensions": { "minHeight": false }
   },
   "editorScript": "file:./index.js",
   "style": "file:./style-index.css",

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -7,7 +7,7 @@ import './editor.css';
 
 registerBlockType('lb-jewelry/hero', {
   edit: ({ attributes, setAttributes }) => {
-    const { title, subtitle, coverURL, overlayOpacity, minHeight } = attributes;
+    const { title, subtitle, coverURL, overlayOpacity } = attributes;
     const blockProps = useBlockProps({ className: 'wpgcb-hero' });
 
     return (
@@ -31,17 +31,9 @@ registerBlockType('lb-jewelry/hero', {
               max={0.8}
               step={0.05}
             />
-            <RangeControl
-              label={__('Minimum height (px)', 'luxurybazaar_jewelry')}
-              value={minHeight}
-              onChange={(v) => setAttributes({ minHeight: v })}
-              min={280}
-              max={800}
-              step={10}
-            />
           </PanelBody>
         </InspectorControls>
-        <div {...blockProps} style={{ minHeight: minHeight + 'px' }}>
+        <div {...blockProps}>
           {coverURL && <img className="wpgcb-hero__cover" src={coverURL} alt="" />}
           <div className="wpgcb-hero__overlay" style={{ opacity: overlayOpacity }} />
           <div className="wpgcb-hero__rect wpgcb-hero__rect--left" />
@@ -67,8 +59,8 @@ registerBlockType('lb-jewelry/hero', {
     );
   },
   save: ({ attributes }) => {
-    const { title, subtitle, coverURL, overlayOpacity, minHeight } = attributes;
-    const blockProps = useBlockProps.save({ className: 'wpgcb-hero', style: { minHeight: minHeight + 'px' } });
+    const { title, subtitle, coverURL, overlayOpacity } = attributes;
+    const blockProps = useBlockProps.save({ className: 'wpgcb-hero' });
     return (
       <div {...blockProps}>
         {coverURL && <img className="wpgcb-hero__cover" src={coverURL} alt="" />}

--- a/src/blocks/hero/style.css
+++ b/src/blocks/hero/style.css
@@ -1,4 +1,4 @@
-.wpgcb-hero { position:relative; display:flex; flex-direction:column; justify-content:flex-end; text-align:center; color:#fff; padding:2rem; padding-bottom:calc(2rem + 100px); overflow:hidden; width:100%; }
+.wpgcb-hero { position:relative; display:flex; flex-direction:column; justify-content:flex-end; text-align:center; color:#fff; padding:2rem; padding-bottom:calc(2rem + 100px); overflow:hidden; width:100%; min-height:100vh; }
 .wpgcb-hero__cover { position:absolute; inset:0; width:100%; height:100%; object-fit:cover; z-index:0; filter:saturate(1.05); }
 .wpgcb-hero__overlay { position:absolute; inset:0; background:#000; z-index:1; }
 .wpgcb-hero__rect { position:absolute; bottom:0; width:180px; height:100px; background:rgba(255,255,255,.3); z-index:2; }


### PR DESCRIPTION
## Summary
- remove inline min-height from hero block so CSS can stretch hero to full viewport
- disable block min-height setting so CSS `min-height: 100vh` takes effect

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cbdd452b083269944351e3d45809e