### PR TITLE
Add mobile-friendly carousel using Swiper

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "wp-scripts start"
   },
   "devDependencies": {
-    "@wordpress/scripts": "^26.14.0"
+    "@wordpress/scripts": "^26.14.0",
+    "swiper": "^11.0.5"
   }
 }

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -7,12 +7,18 @@
   "description": "Image carousel block.",
   "textdomain": "luxurybazaar_jewelry",
   "attributes": {
-    "images": { "type": "array", "default": [] }
+    "images": { "type": "array", "default": [] },
+    "autoplay": { "type": "boolean", "default": true },
+    "autoplayDelay": { "type": "number", "default": 3000 },
+    "loop": { "type": "boolean", "default": true },
+    "showPagination": { "type": "boolean", "default": true },
+    "showNavigation": { "type": "boolean", "default": true }
   },
   "supports": {
     "html": false
   },
   "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
   "style": "file:./style-index.css",
   "editorStyle": "file:./index.css"
 }

--- a/src/blocks/carousel/editor.css
+++ b/src/blocks/carousel/editor.css
@@ -1,2 +1,2 @@
-.wpgcb-carousel { display:flex; overflow-x:auto; gap:1rem; }
-.wpgcb-carousel__image { flex:0 0 auto; width:200px; height:auto; }
+.wpgcb-carousel .swiper { width:100%; }
+.wpgcb-carousel__image { display:block; width:100%; height:auto; }

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -1,13 +1,35 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { MediaUpload, MediaUploadCheck, useBlockProps } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import {
+  InspectorControls,
+  MediaUpload,
+  MediaUploadCheck,
+  useBlockProps
+} from '@wordpress/block-editor';
+import {
+  Button,
+  PanelBody,
+  RangeControl,
+  ToggleControl
+} from '@wordpress/components';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination, Autoplay } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
 import './style.css';
 import './editor.css';
 
 registerBlockType('lb-jewelry/carousel', {
   edit: ({ attributes, setAttributes }) => {
-    const { images = [] } = attributes;
+    const {
+      images = [],
+      autoplay,
+      autoplayDelay,
+      loop,
+      showPagination,
+      showNavigation
+    } = attributes;
     const blockProps = useBlockProps({ className: 'wpgcb-carousel' });
 
     const onSelectImages = (newImages) => {
@@ -15,36 +37,108 @@ registerBlockType('lb-jewelry/carousel', {
     };
 
     return (
-      <div {...blockProps}>
-        <MediaUploadCheck>
-          <MediaUpload
-            onSelect={onSelectImages}
-            allowedTypes={['image']}
-            multiple
-            gallery
-            render={({ open }) => (
-              <Button variant="primary" onClick={open}>
-                { images.length ? __('Edit images', 'luxurybazaar_jewelry') : __('Add images', 'luxurybazaar_jewelry') }
-              </Button>
+      <>
+        <InspectorControls>
+          <PanelBody title={__('Carousel Settings', 'luxurybazaar_jewelry')}>
+            <ToggleControl
+              label={__('Autoplay', 'luxurybazaar_jewelry')}
+              checked={autoplay}
+              onChange={(v) => setAttributes({ autoplay: v })}
+            />
+            {autoplay && (
+              <RangeControl
+                label={__('Autoplay delay (ms)', 'luxurybazaar_jewelry')}
+                value={autoplayDelay}
+                onChange={(v) => setAttributes({ autoplayDelay: v })}
+                min={1000}
+                max={10000}
+                step={500}
+              />
             )}
-          />
-        </MediaUploadCheck>
-        <div className="wpgcb-carousel__images">
-          {images.map((src, index) => (
-            <img src={src} className="wpgcb-carousel__image" alt="" key={index} />
-          ))}
+            <ToggleControl
+              label={__('Loop', 'luxurybazaar_jewelry')}
+              checked={loop}
+              onChange={(v) => setAttributes({ loop: v })}
+            />
+            <ToggleControl
+              label={__('Show Pagination', 'luxurybazaar_jewelry')}
+              checked={showPagination}
+              onChange={(v) => setAttributes({ showPagination: v })}
+            />
+            <ToggleControl
+              label={__('Show Navigation', 'luxurybazaar_jewelry')}
+              checked={showNavigation}
+              onChange={(v) => setAttributes({ showNavigation: v })}
+            />
+          </PanelBody>
+        </InspectorControls>
+        <div {...blockProps}>
+          <MediaUploadCheck>
+            <MediaUpload
+              onSelect={onSelectImages}
+              allowedTypes={['image']}
+              multiple
+              gallery
+              render={({ open }) => (
+                <Button variant="primary" onClick={open}>
+                  { images.length ? __('Edit images', 'luxurybazaar_jewelry') : __('Add images', 'luxurybazaar_jewelry') }
+                </Button>
+              )}
+            />
+          </MediaUploadCheck>
+          {images.length > 0 && (
+            <Swiper
+              modules={[Navigation, Pagination, Autoplay]}
+              loop={loop}
+              autoplay={autoplay ? { delay: autoplayDelay } : false}
+              pagination={showPagination ? { clickable: true } : false}
+              navigation={showNavigation}
+            >
+              {images.map((src, index) => (
+                <SwiperSlide key={index}>
+                  <img src={src} className="wpgcb-carousel__image" alt="" />
+                </SwiperSlide>
+              ))}
+            </Swiper>
+          )}
         </div>
-      </div>
+      </>
     );
   },
   save: ({ attributes }) => {
-    const { images = [] } = attributes;
-    const blockProps = useBlockProps.save({ className: 'wpgcb-carousel' });
+    const {
+      images = [],
+      autoplay,
+      autoplayDelay,
+      loop,
+      showPagination,
+      showNavigation
+    } = attributes;
+    const blockProps = useBlockProps.save({
+      className: 'wpgcb-carousel',
+      'data-autoplay': autoplay ? autoplayDelay : 0,
+      'data-loop': loop,
+      'data-pagination': showPagination,
+      'data-navigation': showNavigation
+    });
     return (
       <div {...blockProps}>
-        {images.map((src, index) => (
-          <img src={src} className="wpgcb-carousel__image" alt="" key={index} />
-        ))}
+        <div className="swiper">
+          <div className="swiper-wrapper">
+            {images.map((src, index) => (
+              <div className="swiper-slide" key={index}>
+                <img src={src} className="wpgcb-carousel__image" alt="" />
+              </div>
+            ))}
+          </div>
+          {showPagination && <div className="swiper-pagination" />}
+          {showNavigation && (
+            <>
+              <div className="swiper-button-prev" />
+              <div className="swiper-button-next" />
+            </>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/blocks/carousel/style.css
+++ b/src/blocks/carousel/style.css
@@ -1,2 +1,2 @@
-.wpgcb-carousel { display:flex; overflow-x:auto; gap:1rem; }
-.wpgcb-carousel__image { flex:0 0 auto; width:200px; height:auto; }
+.wpgcb-carousel .swiper { width:100%; }
+.wpgcb-carousel__image { display:block; width:100%; height:auto; }

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -1,0 +1,26 @@
+import Swiper, { Navigation, Pagination, Autoplay } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.wpgcb-carousel').forEach((block) => {
+    const autoplayDelay = parseInt(block.dataset.autoplay, 10);
+    const loop = block.dataset.loop === 'true';
+    const pagination = block.dataset.pagination === 'true';
+    const navigation = block.dataset.navigation === 'true';
+    const swiperEl = block.querySelector('.swiper');
+    if (!swiperEl) return;
+
+    new Swiper(swiperEl, {
+      modules: [Navigation, Pagination, Autoplay],
+      loop,
+      autoplay: autoplayDelay ? { delay: autoplayDelay } : false,
+      pagination: pagination ? { el: block.querySelector('.swiper-pagination'), clickable: true } : false,
+      navigation: navigation ? {
+        nextEl: block.querySelector('.swiper-button-next'),
+        prevEl: block.querySelector('.swiper-button-prev')
+      } : false
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- convert image gallery to Swiper-based carousel
- expose autoplay, loop, pagination and navigation settings
- initialize carousel on front-end

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Can't resolve 'swiper/react')*


------
https://chatgpt.com/codex/tasks/task_e_689cdc73b05883269cc21d2217b2f695