### PR TITLE
Add configurable carousel slider

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "wp-scripts build",
     "start": "wp-scripts start"
   },
+  "dependencies": {
+    "swiper": "^10.0.0"
+  },
   "devDependencies": {
     "@wordpress/scripts": "^26.14.0"
   }

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -7,12 +7,15 @@
   "description": "Image carousel block.",
   "textdomain": "luxurybazaar_jewelry",
   "attributes": {
-    "images": { "type": "array", "default": [] }
+    "images": { "type": "array", "default": [] },
+    "autoplay": { "type": "boolean", "default": false },
+    "loop": { "type": "boolean", "default": false }
   },
   "supports": {
     "html": false
   },
   "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
   "style": "file:./style-index.css",
   "editorStyle": "file:./index.css"
 }

--- a/src/blocks/carousel/editor.css
+++ b/src/blocks/carousel/editor.css
@@ -1,2 +1,14 @@
-.wpgcb-carousel { display:flex; overflow-x:auto; gap:1rem; }
-.wpgcb-carousel__image { flex:0 0 auto; width:200px; height:auto; }
+.wpgcb-carousel {
+  position: relative;
+}
+
+.swiper-slide img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.swiper-button-prev,
+.swiper-button-next {
+  color: #fff;
+}

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -1,13 +1,27 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { MediaUpload, MediaUploadCheck, useBlockProps } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
+import {
+  MediaUpload,
+  MediaUploadCheck,
+  useBlockProps,
+  InspectorControls
+} from '@wordpress/block-editor';
+import {
+  Button,
+  PanelBody,
+  ToggleControl
+} from '@wordpress/components';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Navigation, Pagination, Autoplay } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
 import './style.css';
 import './editor.css';
 
 registerBlockType('lb-jewelry/carousel', {
   edit: ({ attributes, setAttributes }) => {
-    const { images = [] } = attributes;
+    const { images = [], autoplay = false, loop = false } = attributes;
     const blockProps = useBlockProps({ className: 'wpgcb-carousel' });
 
     const onSelectImages = (newImages) => {
@@ -15,36 +29,73 @@ registerBlockType('lb-jewelry/carousel', {
     };
 
     return (
-      <div {...blockProps}>
-        <MediaUploadCheck>
-          <MediaUpload
-            onSelect={onSelectImages}
-            allowedTypes={['image']}
-            multiple
-            gallery
-            render={({ open }) => (
-              <Button variant="primary" onClick={open}>
-                { images.length ? __('Edit images', 'luxurybazaar_jewelry') : __('Add images', 'luxurybazaar_jewelry') }
-              </Button>
-            )}
-          />
-        </MediaUploadCheck>
-        <div className="wpgcb-carousel__images">
-          {images.map((src, index) => (
-            <img src={src} className="wpgcb-carousel__image" alt="" key={index} />
-          ))}
+      <>
+        <InspectorControls>
+          <PanelBody title={__('Carousel Settings', 'luxurybazaar_jewelry')} initialOpen={true}>
+            <ToggleControl
+              label={__('Autoplay', 'luxurybazaar_jewelry')}
+              checked={autoplay}
+              onChange={(value) => setAttributes({ autoplay: value })}
+            />
+            <ToggleControl
+              label={__('Loop', 'luxurybazaar_jewelry')}
+              checked={loop}
+              onChange={(value) => setAttributes({ loop: value })}
+            />
+          </PanelBody>
+        </InspectorControls>
+        <div {...blockProps}>
+          <MediaUploadCheck>
+            <MediaUpload
+              onSelect={onSelectImages}
+              allowedTypes={['image']}
+              multiple
+              gallery
+              render={({ open }) => (
+                <Button variant="primary" onClick={open}>
+                  { images.length ? __('Edit images', 'luxurybazaar_jewelry') : __('Add images', 'luxurybazaar_jewelry') }
+                </Button>
+              )}
+            />
+          </MediaUploadCheck>
+          {images.length > 0 && (
+            <Swiper
+              modules={[Navigation, Pagination, Autoplay]}
+              navigation
+              pagination={{ clickable: true }}
+              autoplay={autoplay ? { delay: 3000 } : false}
+              loop={loop}
+            >
+              {images.map((src, index) => (
+                <SwiperSlide key={index}>
+                  <img src={src} alt="" />
+                </SwiperSlide>
+              ))}
+            </Swiper>
+          )}
         </div>
-      </div>
+      </>
     );
   },
   save: ({ attributes }) => {
-    const { images = [] } = attributes;
-    const blockProps = useBlockProps.save({ className: 'wpgcb-carousel' });
+    const { images = [], autoplay = false, loop = false } = attributes;
+    const blockProps = useBlockProps.save({
+      className: 'wpgcb-carousel swiper',
+      'data-autoplay': autoplay,
+      'data-loop': loop
+    });
     return (
       <div {...blockProps}>
-        {images.map((src, index) => (
-          <img src={src} className="wpgcb-carousel__image" alt="" key={index} />
-        ))}
+        <div className="swiper-wrapper">
+          {images.map((src, index) => (
+            <div className="swiper-slide" key={index}>
+              <img src={src} alt="" />
+            </div>
+          ))}
+        </div>
+        <div className="swiper-button-prev"></div>
+        <div className="swiper-button-next"></div>
+        <div className="swiper-pagination"></div>
       </div>
     );
   }

--- a/src/blocks/carousel/style.css
+++ b/src/blocks/carousel/style.css
@@ -1,2 +1,14 @@
-.wpgcb-carousel { display:flex; overflow-x:auto; gap:1rem; }
-.wpgcb-carousel__image { flex:0 0 auto; width:200px; height:auto; }
+.wpgcb-carousel {
+  position: relative;
+}
+
+.swiper-slide img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.swiper-button-prev,
+.swiper-button-next {
+  color: #fff;
+}

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -1,0 +1,24 @@
+import Swiper, { Navigation, Pagination, Autoplay } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.wpgcb-carousel').forEach((el) => {
+    const autoplay = el.dataset.autoplay === 'true';
+    const loop = el.dataset.loop === 'true';
+    new Swiper(el, {
+      modules: [Navigation, Pagination, Autoplay],
+      navigation: {
+        nextEl: el.querySelector('.swiper-button-next'),
+        prevEl: el.querySelector('.swiper-button-prev'),
+      },
+      pagination: {
+        el: el.querySelector('.swiper-pagination'),
+        clickable: true,
+      },
+      autoplay: autoplay ? { delay: 3000 } : false,
+      loop,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace custom carousel with Swiper-based slider supporting autoplay and loop options
- load Swiper on both editor and front end with navigation and pagination controls
- add Swiper dependency and styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot resolve 'swiper' modules)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc73b05883269cc21d2217b2f695