### PR TITLE
Fix spotlight block style path

### DIFF
--- a/src/blocks/brand-spotlight/block.json
+++ b/src/blocks/brand-spotlight/block.json
@@ -42,7 +42,7 @@
     }
   },
   "editorScript": "file:./index.js",
-  "style": "file:./style.css",
+  "style": "file:./style-index.css",
   "viewScript": "file:./view.js",
-  "editorStyle": "file:./editor.css"
+  "editorStyle": "file:./index.css"
 }


### PR DESCRIPTION
## Summary
- Fix brand spotlight block's stylesheet references so compiled CSS loads in editor and front end.

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d9393d31083269376b08269b38485