### PR TITLE
Add zoom and fade animations to brand spotlight

### DIFF
--- a/src/blocks/brand-spotlight/style.css
+++ b/src/blocks/brand-spotlight/style.css
@@ -1,8 +1,29 @@
-.bs-carousel { position: relative; width: 100%; }
-.bs-slide { width: 100%; height: 600px; }
+.bs-carousel { position: relative; width: 100%; overflow: hidden; }
+.bs-slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+.bs-slide.is-active {
+  opacity: 1;
+  z-index: 1;
+}
 .bs-grid { display: grid; grid-template-columns: 1fr 1fr; height: 100%; }
 .bs-left { overflow: hidden; }
-.bs-left img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.bs-slide.is-active .bs-left img {
+  animation: bs-zoom 20s linear forwards;
+}
+.bs-left img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transform-origin: center center;
+}
 .bs-right { background: #FBFBFB; display: flex; align-items: center; justify-content: center; }
 .bs-inner { max-width: 520px; text-align: center; }
 .bs-eyebrow {
@@ -65,8 +86,11 @@
 .bs-dots { margin-top: 1.25rem; display: flex; gap: .6rem; justify-content: center; }
 .bs-dot { width: 8px; height: 8px; border-radius: 999px; border: none; background: #000; opacity: .9; cursor: pointer; }
 .bs-dot.is-active { background: #ff7c52; opacity: 1; }
+@keyframes bs-zoom {
+  from { transform: scale(1); }
+  to { transform: scale(1.1); }
+}
 @media (max-width: 960px) {
-  .bs-slide { height: auto; }
   .bs-grid { grid-template-columns: 1fr; height: auto; }
   .bs-right { padding: 2rem 1.25rem; }
 }

--- a/src/blocks/brand-spotlight/view.js
+++ b/src/blocks/brand-spotlight/view.js
@@ -16,10 +16,16 @@
       });
     }
     function show(i) {
-      index = (i + slides.length) % slides.length;
-      slides.forEach((s, idx) => {
-        s.style.display = idx === index ? 'block' : 'none';
-      });
+      const nextIndex = (i + slides.length) % slides.length;
+      if (nextIndex === index) return;
+      const prevSlide = slides[index];
+      const nextSlide = slides[nextIndex];
+      if (prevSlide) prevSlide.classList.remove('is-active');
+      if (nextSlide) {
+        nextSlide.classList.add('is-active');
+        root.style.height = nextSlide.offsetHeight + 'px';
+      }
+      index = nextIndex;
       updateDots(index);
     }
     function next() { show(index + 1); }
@@ -42,8 +48,14 @@
     root.addEventListener('mouseleave', start);
 
     // init
-    slides.forEach((s, idx) => s.style.display = idx === 0 ? 'block' : 'none');
-    show(0);
+    slides.forEach((s, idx) => {
+      s.classList.toggle('is-active', idx === 0);
+    });
+    index = 0;
+    if (slides[0]) {
+      root.style.height = slides[0].offsetHeight + 'px';
+    }
+    updateDots(0);
     start();
   }
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Add smooth zoom-in animation to spotlight images
- Cross-fade slides for smoother transitions and adjust container height dynamically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da1076cf48326b8c69815bde0dd4a