### PR TITLE
Add zoom and fade animations to brand spotlight

### DIFF
--- a/src/blocks/brand-spotlight/style.css
+++ b/src/blocks/brand-spotlight/style.css
@@ -1,9 +1,30 @@
-.bs-carousel { position: relative; width: 100%; }
-.bs-slide { width: 100%; height: 600px; }
+.bs-carousel { position: relative; width: 100%; height: 600px; max-height: 600px; overflow: hidden; }
+.bs-slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+.bs-slide.is-active {
+  opacity: 1;
+  z-index: 1;
+}
 .bs-grid { display: grid; grid-template-columns: 1fr 1fr; height: 100%; }
-.bs-left { overflow: hidden; }
-.bs-left img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.bs-right { background: #FBFBFB; display: flex; align-items: center; justify-content: center; }
+.bs-left { overflow: hidden; height: 100%; }
+.bs-slide.is-active .bs-left img {
+  animation: bs-zoom 10s linear forwards;
+}
+.bs-left img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transform-origin: center center;
+}
+.bs-right { background: #FBFBFB; display: flex; align-items: center; justify-content: center; height: 100%; }
 .bs-inner { max-width: 520px; text-align: center; }
 .bs-eyebrow {
   color: #AAA;
@@ -65,8 +86,11 @@
 .bs-dots { margin-top: 1.25rem; display: flex; gap: .6rem; justify-content: center; }
 .bs-dot { width: 8px; height: 8px; border-radius: 999px; border: none; background: #000; opacity: .9; cursor: pointer; }
 .bs-dot.is-active { background: #ff7c52; opacity: 1; }
+@keyframes bs-zoom {
+  from { transform: scale(1); }
+  to { transform: scale(1.1); }
+}
 @media (max-width: 960px) {
-  .bs-slide { height: auto; }
   .bs-grid { grid-template-columns: 1fr; height: auto; }
   .bs-right { padding: 2rem 1.25rem; }
 }

--- a/src/blocks/brand-spotlight/view.js
+++ b/src/blocks/brand-spotlight/view.js
@@ -16,10 +16,13 @@
       });
     }
     function show(i) {
-      index = (i + slides.length) % slides.length;
-      slides.forEach((s, idx) => {
-        s.style.display = idx === index ? 'block' : 'none';
-      });
+      const nextIndex = (i + slides.length) % slides.length;
+      if (nextIndex === index) return;
+      const prevSlide = slides[index];
+      const nextSlide = slides[nextIndex];
+      if (prevSlide) prevSlide.classList.remove('is-active');
+      if (nextSlide) nextSlide.classList.add('is-active');
+      index = nextIndex;
       updateDots(index);
     }
     function next() { show(index + 1); }
@@ -42,8 +45,11 @@
     root.addEventListener('mouseleave', start);
 
     // init
-    slides.forEach((s, idx) => s.style.display = idx === 0 ? 'block' : 'none');
-    show(0);
+    slides.forEach((s, idx) => {
+      s.classList.toggle('is-active', idx === 0);
+    });
+    index = 0;
+    updateDots(0);
     start();
   }
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Limit spotlight carousel height to 600px so slides stay consistent regardless of image size
- Keep images filling the container and speed up the zoom animation for a snappier effect
- Maintain cross-fade slide transitions without dynamic height adjustments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689da1076cf48326b8c69815bde0dd4a