### PR TITLE
Add Image Banner block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # luxurybazaar_jewelry
 
-Blocks: **LBJ - Hero** (`lb-jewelry/hero`), **LBJ - Carousel** (`lb-jewelry/carousel`).
+Blocks: **LBJ - Hero** (`lb-jewelry/hero`), **LBJ - Carousel** (`lb-jewelry/carousel`), **LBJ - Brand Spotlight** (`lb-jewelry/brand-spotlight`), **LBJ - Image Banner** (`lb-jewelry/image-banner`).
 
 ## Build
 ```bash
@@ -9,4 +9,4 @@ npm run build
 ```
 
 ## Notes
-- Block names are hyphenated (`lb-jewelry/hero`, `lb-jewelry/carousel`) per Gutenberg rules.
+- Block names are hyphenated (`lb-jewelry/hero`, `lb-jewelry/carousel`, `lb-jewelry/brand-spotlight`, `lb-jewelry/image-banner`) per Gutenberg rules.

--- a/index.php
+++ b/index.php
@@ -23,5 +23,6 @@ function lb_jewelry_register_blocks() {
     register_block_type( __DIR__ . '/build/blocks/hero' );
     register_block_type( __DIR__ . '/build/blocks/carousel' );
     register_block_type( __DIR__ . '/build/blocks/brand-spotlight' );
+    register_block_type( __DIR__ . '/build/blocks/image-banner' );
 }
 add_action( 'init', 'lb_jewelry_register_blocks' );

--- a/src/blocks/image-banner/block.json
+++ b/src/blocks/image-banner/block.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": 2,
+  "name": "lb-jewelry/image-banner",
+  "title": "LBJ - Image Banner",
+  "category": "design",
+  "icon": "cover-image",
+  "description": "Full-width image with right overlay content.",
+  "textdomain": "luxurybazaar_jewelry",
+  "attributes": {
+    "title": { "type": "string", "default": "Banner Title" },
+    "subtitle": { "type": "string", "default": "Banner subtitle goes here." },
+    "buttonText": { "type": "string", "default": "Learn More" },
+    "buttonURL": { "type": "string", "default": "" },
+    "imageURL": { "type": "string", "default": "" },
+    "align": { "type": "string", "default": "full" }
+  },
+  "supports": {
+    "html": false,
+    "align": ["full"],
+    "spacing": { "padding": true, "margin": true }
+  },
+  "editorScript": "file:./index.js",
+  "style": "file:./style-index.css",
+  "editorStyle": "file:./index.css"
+}

--- a/src/blocks/image-banner/index.js
+++ b/src/blocks/image-banner/index.js
@@ -1,0 +1,81 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, MediaUpload, RichText, URLInputButton, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, Button } from '@wordpress/components';
+import './style.css';
+import './editor.css';
+
+registerBlockType('lb-jewelry/image-banner', {
+  edit: ({ attributes, setAttributes }) => {
+    const { title, subtitle, buttonText, buttonURL, imageURL } = attributes;
+    const blockProps = useBlockProps({ className: 'wpgcb-image-banner' });
+
+    return (
+      <>
+        <InspectorControls>
+          <PanelBody title={__('Background Image', 'luxurybazaar_jewelry')} initialOpen={true}>
+            <MediaUpload
+              onSelect={(media) => setAttributes({ imageURL: media.url })}
+              allowedTypes={['image']}
+              render={({ open }) => (
+                <Button variant="primary" onClick={open}>
+                  { imageURL ? __('Change image', 'luxurybazaar_jewelry') : __('Choose image', 'luxurybazaar_jewelry') }
+                </Button>
+              )}
+            />
+          </PanelBody>
+          <PanelBody title={__('Button Link', 'luxurybazaar_jewelry')} initialOpen={false}>
+            <URLInputButton
+              url={buttonURL}
+              onChange={(url) => setAttributes({ buttonURL: url })}
+            />
+          </PanelBody>
+        </InspectorControls>
+        <div {...blockProps}>
+          {imageURL && <img className="wpgcb-image-banner__img" src={imageURL} alt="" />}
+          <div className="wpgcb-image-banner__box">
+            <RichText
+              tagName="h2"
+              className="wpgcb-image-banner__title"
+              value={title}
+              onChange={(v) => setAttributes({ title: v })}
+              placeholder={__('Add title…', 'luxurybazaar_jewelry')}
+            />
+            <RichText
+              tagName="p"
+              className="wpgcb-image-banner__subtitle"
+              value={subtitle}
+              onChange={(v) => setAttributes({ subtitle: v })}
+              placeholder={__('Add subtitle…', 'luxurybazaar_jewelry')}
+            />
+            <RichText
+              tagName="a"
+              className="wpgcb-image-banner__button"
+              value={buttonText}
+              onChange={(v) => setAttributes({ buttonText: v })}
+              placeholder={__('Add button text…', 'luxurybazaar_jewelry')}
+              href={buttonURL}
+            />
+          </div>
+        </div>
+      </>
+    );
+  },
+  save: ({ attributes }) => {
+    const { title, subtitle, buttonText, buttonURL, imageURL } = attributes;
+    const blockProps = useBlockProps.save({ className: 'wpgcb-image-banner' });
+
+    return (
+      <div {...blockProps}>
+        {imageURL && <img className="wpgcb-image-banner__img" src={imageURL} alt="" />}
+        <div className="wpgcb-image-banner__box">
+          <RichText.Content tagName="h2" className="wpgcb-image-banner__title" value={title} />
+          <RichText.Content tagName="p" className="wpgcb-image-banner__subtitle" value={subtitle} />
+          {buttonText && (
+            <RichText.Content tagName="a" className="wpgcb-image-banner__button" href={buttonURL} value={buttonText} />
+          )}
+        </div>
+      </div>
+    );
+  }
+});

--- a/src/blocks/image-banner/style.css
+++ b/src/blocks/image-banner/style.css
@@ -1,0 +1,57 @@
+.wpgcb-image-banner {
+  position: relative;
+  width: 100%;
+  min-height: 500px;
+  display: flex;
+}
+.wpgcb-image-banner__img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.wpgcb-image-banner__box {
+  margin-left: auto;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  padding: 2rem;
+  max-width: 40%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  z-index: 1;
+}
+.wpgcb-image-banner__title {
+  margin: 0 0 1rem;
+  color: #fff;
+  font-family: Cardo;
+  font-size: 64px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+.wpgcb-image-banner__subtitle {
+  margin: 0 0 1.5rem;
+  color: #fff;
+  font-family: Lato;
+  font-size: 20px;
+  line-height: 1.4;
+}
+.wpgcb-image-banner__button {
+  align-self: center;
+  background: #fff;
+  color: #000;
+  text-decoration: none;
+  padding: .75rem 1.5rem;
+  font-family: Roboto;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+@media (max-width: 768px) {
+  .wpgcb-image-banner__box {
+    max-width: 100%;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 import './blocks/hero';
 import './blocks/carousel';
+import './blocks/image-banner';


### PR DESCRIPTION
## Summary
- add image-banner block with right-side overlay content
- wire block into build and plugin registration
- document available blocks in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689daedf8b6c832689e1108221ac238a