### PR TITLE
style: update image banner overlay and typography

### DIFF
--- a/src/blocks/image-banner/style.css
+++ b/src/blocks/image-banner/style.css
@@ -2,7 +2,6 @@
   position: relative;
   width: 100%;
   min-height: 500px;
-  display: flex;
 }
 .wpgcb-image-banner__img {
   position: absolute;
@@ -12,42 +11,62 @@
   object-fit: cover;
 }
 .wpgcb-image-banner__box {
-  margin-left: auto;
-  background: rgba(0,0,0,0.5);
-  color: #fff;
-  padding: 2rem;
-  max-width: 40%;
-  width: 100%;
+  position: absolute;
+  top: 50%;
+  left: 75%;
+  transform: translate(-50%, -50%);
   display: flex;
+  width: 484px;
+  height: 266px;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.3);
   text-align: center;
   z-index: 1;
 }
 .wpgcb-image-banner__title {
-  margin: 0 0 1rem;
+  margin: 0;
   color: #fff;
   font-family: Cardo;
-  font-size: 64px;
+  font-size: 45.1px;
+  font-style: normal;
   font-weight: 700;
-  line-height: 1.1;
+  line-height: 49.59px;
+  text-align: center;
 }
+
 .wpgcb-image-banner__subtitle {
-  margin: 0 0 1.5rem;
+  margin: 0;
   color: #fff;
-  font-family: Lato;
-  font-size: 20px;
-  line-height: 1.4;
+  font-family: Roboto;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 28.8px;
+  text-align: center;
 }
+
 .wpgcb-image-banner__button {
-  align-self: center;
+  display: flex;
+  width: 200px;
+  height: 44px;
+  padding: 11px 39.58px 11px 39.56px;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
   background: #fff;
   color: #000;
+  text-align: center;
   text-decoration: none;
-  padding: .75rem 1.5rem;
   font-family: Roboto;
   font-size: 14px;
+  font-style: normal;
   font-weight: 700;
+  line-height: 22.4px;
   text-transform: uppercase;
 }
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- center image banner overlay in right half and adjust its dimensions
- refine heading, subtitle, and button typography and layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dbcd064408326a9703b3adbe13834