### PR TITLE
Properly center image banner overlay

### DIFF
--- a/src/blocks/image-banner/style.css
+++ b/src/blocks/image-banner/style.css
@@ -13,7 +13,7 @@
 .wpgcb-image-banner__box {
   position: absolute;
   top: 50%;
-  left: 75%;
+  left: 50%;
   transform: translate(-50%, -50%);
   display: flex;
   width: 484px;


### PR DESCRIPTION
## Summary
- Revert to absolute positioning and center banner overlay both vertically and horizontally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dbedbd32083268f994a4cee521644