### PR TITLE
feat: add custom carousel slides with editable heading

### DIFF
--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -8,7 +8,10 @@
   "textdomain": "luxurybazaar_jewelry",
   "attributes": {
     "autoplay": { "type": "boolean", "default": false },
-    "loop": { "type": "boolean", "default": false }
+    "loop": { "type": "boolean", "default": false },
+    "mode": { "type": "string", "default": "latest" },
+    "heading": { "type": "string", "default": "" },
+    "slides": { "type": "array", "default": [] }
   },
   "supports": {
     "html": false

--- a/src/blocks/carousel/editor.css
+++ b/src/blocks/carousel/editor.css
@@ -5,6 +5,14 @@
   margin: 0 auto;
 }
 
+.wpgcb-carousel-heading {
+  text-align: center;
+  font-family: 'Roboto Condensed';
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 20px;
+}
+
 .swiper-slide img {
   display: block;
   width: 100%;

--- a/src/blocks/carousel/style.css
+++ b/src/blocks/carousel/style.css
@@ -5,6 +5,14 @@
   margin: 0 auto;
 }
 
+.wpgcb-carousel-heading {
+  text-align: center;
+  font-family: 'Roboto Condensed';
+  font-size: 24px;
+  font-weight: 700;
+  margin-bottom: 20px;
+}
+
 .swiper-slide img {
   display: block;
   width: 100%;

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -44,70 +44,79 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.wpgcb-carousel').forEach((el) => {
     const autoplay = el.dataset.autoplay === 'true';
     const loop = el.dataset.loop === 'true';
+    const mode = el.dataset.mode || 'latest';
 
-    const url =
-      '/wp-json/wc/store/v1/products' +
-      '?attributes[0][attribute]=pa_product_type' +
-      '&attributes[0][slug]=jewelry' +
-      '&per_page=10';
-
-    fetch(url)
-      .then((res) => res.json())
-      .then((products) => {
-        if (!Array.isArray(products)) return;
-        const wrapper = el.querySelector('.swiper-wrapper');
-        if (!wrapper) return;
-
-        products.forEach((product) => {
-          const imgSrc = product.images?.[0]?.src;
-          if (!imgSrc) return;
-
-          const slide = document.createElement('div');
-          slide.className = 'swiper-slide';
-
-          const img = document.createElement('img');
-          img.src = imgSrc;
-          img.alt = product.name || '';
-          slide.appendChild(img);
-
-          const brand = getBrand(product);
-          if (brand) {
-            const brandEl = document.createElement('div');
-            brandEl.className = 'product-brand';
-            brandEl.textContent = brand;
-            slide.appendChild(brandEl);
-          }
-
-          const titleEl = document.createElement('div');
-          titleEl.className = 'product-title';
-          titleEl.textContent = product.name || '';
-          slide.appendChild(titleEl);
-
-          wrapper.appendChild(slide);
-        });
-
-        new Swiper(el, {
-          modules: [Navigation, Pagination, Autoplay],
-          slidesPerView: 1,
-          breakpoints: {
-            480: { slidesPerView: 2 },
-            768: { slidesPerView: 3 },
-            1024: { slidesPerView: 5 },
-          },
-          navigation: {
-            nextEl: el.querySelector('.swiper-button-next'),
-            prevEl: el.querySelector('.swiper-button-prev'),
-          },
-          pagination: {
-            el: el.querySelector('.swiper-pagination'),
-            clickable: true,
-          },
-          autoplay: autoplay ? { delay: 3000 } : false,
-          loop,
-        });
-      })
-      .catch(() => {
-        // Optional: handle error state
+    const initSwiper = () => {
+      new Swiper(el, {
+        modules: [Navigation, Pagination, Autoplay],
+        slidesPerView: 1,
+        breakpoints: {
+          480: { slidesPerView: 2 },
+          768: { slidesPerView: 3 },
+          1024: { slidesPerView: 5 },
+        },
+        navigation: {
+          nextEl: el.querySelector('.swiper-button-next'),
+          prevEl: el.querySelector('.swiper-button-prev'),
+        },
+        pagination: {
+          el: el.querySelector('.swiper-pagination'),
+          clickable: true,
+        },
+        autoplay: autoplay ? { delay: 3000 } : false,
+        loop,
       });
+    };
+
+    if (mode === 'latest') {
+      const url =
+        '/wp-json/wc/store/v1/products' +
+        '?attributes[0][attribute]=pa_product_type' +
+        '&attributes[0][slug]=jewelry' +
+        '&per_page=10';
+
+      fetch(url)
+        .then((res) => res.json())
+        .then((products) => {
+          if (!Array.isArray(products)) return;
+          const wrapper = el.querySelector('.swiper-wrapper');
+          if (!wrapper) return;
+
+          products.forEach((product) => {
+            const imgSrc = product.images?.[0]?.src;
+            if (!imgSrc) return;
+
+            const slide = document.createElement('div');
+            slide.className = 'swiper-slide';
+
+            const img = document.createElement('img');
+            img.src = imgSrc;
+            img.alt = product.name || '';
+            slide.appendChild(img);
+
+            const brand = getBrand(product);
+            if (brand) {
+              const brandEl = document.createElement('div');
+              brandEl.className = 'product-brand';
+              brandEl.textContent = brand;
+              slide.appendChild(brandEl);
+            }
+
+            const titleEl = document.createElement('div');
+            titleEl.className = 'product-title';
+            titleEl.textContent = product.name || '';
+            slide.appendChild(titleEl);
+
+            wrapper.appendChild(slide);
+          });
+
+          initSwiper();
+        })
+        .catch(() => {
+          // Optional: handle error state
+        });
+    } else {
+      initSwiper();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- allow carousel to show latest jewelry or custom slides
- support custom slide images, links, titles, and editable heading
- initialize swiper based on mode and add heading styles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689dc7cdc3548326bd89df1f2ccd5359