### PR TITLE
feat: add hover images for custom carousel slides

### DIFF
--- a/src/blocks/carousel/editor.css
+++ b/src/blocks/carousel/editor.css
@@ -41,3 +41,34 @@
 .swiper-button-next {
   color: #fff;
 }
+
+/* Hover image support in editor preview */
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper {
+  position: relative;
+}
+
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper img.hover-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper img.main-image {
+  transition: opacity 0.2s ease-in-out;
+}
+
+.wpgcb-carousel[data-mode="custom"] .swiper-slide:hover .carousel-image-wrapper img.hover-image {
+  opacity: 1;
+}
+
+.wpgcb-carousel[data-mode="custom"] .swiper-slide:hover .carousel-image-wrapper img.main-image {
+  opacity: 0;
+}

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -85,7 +85,9 @@ registerBlockType('lb-jewelry/carousel', {
     }, [mode]);
 
     const addSlide = () =>
-      setAttributes({ slides: [...slides, { image: '', url: '', title: '' }] });
+      setAttributes({
+        slides: [...slides, { image: '', hoverImage: '', url: '', title: '' }],
+      });
 
     const updateSlide = (index, field, value) => {
       const newSlides = [...slides];
@@ -153,6 +155,28 @@ registerBlockType('lb-jewelry/carousel', {
                   {slide.image && (
                     <img
                       src={slide.image}
+                      alt=""
+                      style={{ width: '100%', height: 'auto', marginTop: '10px' }}
+                    />
+                  )}
+                  <MediaUploadCheck>
+                    <MediaUpload
+                      onSelect={(media) =>
+                        updateSlide(index, 'hoverImage', media.url || '')
+                      }
+                      allowedTypes={['image']}
+                      render={({ open }) => (
+                        <Button onClick={open} isSecondary>
+                          {slide.hoverImage
+                            ? __('Change Hover Image', 'luxurybazaar_jewelry')
+                            : __('Select Hover Image', 'luxurybazaar_jewelry')}
+                        </Button>
+                      )}
+                    />
+                  </MediaUploadCheck>
+                  {slide.hoverImage && (
+                    <img
+                      src={slide.hoverImage}
                       alt=""
                       style={{ width: '100%', height: 'auto', marginTop: '10px' }}
                     />
@@ -236,31 +260,44 @@ registerBlockType('lb-jewelry/carousel', {
               }}
             >
               {slides.length ? (
-                slides.map((slide, index) => (
-                  <SwiperSlide key={index}>
-                    {slide.url ? (
-                      <a
-                        href={slide.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {slide.image && (
-                          <img
-                            src={slide.image}
-                            alt={slide.title || ''}
-                          />
-                        )}
-                      </a>
-                    ) : (
-                      slide.image && (
-                        <img src={slide.image} alt={slide.title || ''} />
-                      )
-                    )}
-                    {slide.title && (
-                      <div className="product-title">{slide.title}</div>
-                    )}
-                  </SwiperSlide>
-                ))
+                slides.map((slide, index) => {
+                  const imageEl = (
+                    <div className="carousel-image-wrapper">
+                      {slide.image && (
+                        <img
+                          className="main-image"
+                          src={slide.image}
+                          alt={slide.title || ''}
+                        />
+                      )}
+                      {slide.hoverImage && (
+                        <img
+                          className="hover-image"
+                          src={slide.hoverImage}
+                          alt={slide.title || ''}
+                        />
+                      )}
+                    </div>
+                  );
+                  return (
+                    <SwiperSlide key={index}>
+                      {slide.url ? (
+                        <a
+                          href={slide.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {imageEl}
+                        </a>
+                      ) : (
+                        imageEl
+                      )}
+                      {slide.title && (
+                        <div className="product-title">{slide.title}</div>
+                      )}
+                    </SwiperSlide>
+                  );
+                })
               ) : (
                 <SwiperSlide>
                   {__('Add slides in settings', 'luxurybazaar_jewelry')}
@@ -297,24 +334,34 @@ registerBlockType('lb-jewelry/carousel', {
         >
           <div className="swiper-wrapper">
             {mode === 'custom' &&
-              slides.map((slide, index) => (
-                <div className="swiper-slide" key={index}>
-                  {slide.url ? (
-                    <a href={slide.url}>
-                      {slide.image && (
-                        <img src={slide.image} alt={slide.title || ''} />
-                      )}
-                    </a>
-                  ) : (
-                    slide.image && (
-                      <img src={slide.image} alt={slide.title || ''} />
-                    )
-                  )}
-                  {slide.title && (
-                    <div className="product-title">{slide.title}</div>
-                  )}
-                </div>
-              ))}
+              slides.map((slide, index) => {
+                const imageEl = (
+                  <div className="carousel-image-wrapper">
+                    {slide.image && (
+                      <img
+                        className="main-image"
+                        src={slide.image}
+                        alt={slide.title || ''}
+                      />
+                    )}
+                    {slide.hoverImage && (
+                      <img
+                        className="hover-image"
+                        src={slide.hoverImage}
+                        alt={slide.title || ''}
+                      />
+                    )}
+                  </div>
+                );
+                return (
+                  <div className="swiper-slide" key={index}>
+                    {slide.url ? <a href={slide.url}>{imageEl}</a> : imageEl}
+                    {slide.title && (
+                      <div className="product-title">{slide.title}</div>
+                    )}
+                  </div>
+                );
+              })}
           </div>
           <div className="swiper-button-prev"></div>
           <div className="swiper-button-next"></div>

--- a/src/blocks/carousel/style.css
+++ b/src/blocks/carousel/style.css
@@ -87,13 +87,37 @@
     background-color: #fff;
   }
   
-  /* Image in custom slides */
-  .wpgcb-carousel[data-mode="custom"] .swiper-slide img {
-    width: 100%;
-    height: auto;
-    border-radius: 12px;
-    display: block;
-  }
+/* Image in custom slides */
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper {
+  position: relative;
+}
+
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper img {
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  display: block;
+}
+
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper img.hover-image {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.wpgcb-carousel[data-mode="custom"] .carousel-image-wrapper img.main-image {
+  transition: opacity 0.2s ease-in-out;
+}
+
+.wpgcb-carousel[data-mode="custom"] .swiper-slide:hover .carousel-image-wrapper img.hover-image {
+  opacity: 1;
+}
+
+.wpgcb-carousel[data-mode="custom"] .swiper-slide:hover .carousel-image-wrapper img.main-image {
+  opacity: 0;
+}
   
   /* ===============================
      Text under custom items (EXACT values)


### PR DESCRIPTION
## Summary
- support optional hover image for each custom carousel slide
- fade main image out and hover image in on pointer hover

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de14189308326897fdfe76c2acb19