### PR TITLE
feat(hero): add carousel slider support

### DIFF
--- a/src/blocks/hero/block.json
+++ b/src/blocks/hero/block.json
@@ -9,7 +9,7 @@
   "attributes": {
     "title": { "type": "string", "default": "Your Hero Title" },
     "subtitle": { "type": "string", "default": "A short supporting subtitle goes here." },
-    "coverURL": { "type": "string", "default": "" },
+    "coverURLs": { "type": "array", "default": [] },
     "overlayOpacity": { "type": "number", "default": 0.35 },
     "align": { "type": "string", "default": "full" }
   },
@@ -21,6 +21,7 @@
     "dimensions": { "minHeight": false }
   },
   "editorScript": "file:./index.js",
+  "viewScript": "file:./view.js",
   "style": "file:./style-index.css",
   "editorStyle": "file:./index.css"
 }

--- a/src/blocks/hero/index.js
+++ b/src/blocks/hero/index.js
@@ -2,24 +2,34 @@ import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, MediaUpload, RichText, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, Button } from '@wordpress/components';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { EffectFade, Autoplay } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/effect-fade';
 import './style.css';
 import './editor.css';
 
 registerBlockType('lb-jewelry/hero', {
   edit: ({ attributes, setAttributes }) => {
-    const { title, subtitle, coverURL, overlayOpacity } = attributes;
+    const { title, subtitle, coverURLs = [], overlayOpacity } = attributes;
     const blockProps = useBlockProps({ className: 'wpgcb-hero' });
 
     return (
       <>
         <InspectorControls>
-          <PanelBody title={__('Cover Image', 'luxurybazaar_jewelry')} initialOpen={true}>
+          <PanelBody title={__('Hero Images', 'luxurybazaar_jewelry')} initialOpen={true}>
             <MediaUpload
-              onSelect={(media) => setAttributes({ coverURL: media.url })}
+              onSelect={(media) =>
+                setAttributes({ coverURLs: media.map((m) => m.url) })
+              }
               allowedTypes={['image']}
+              multiple
+              gallery
               render={({ open }) => (
                 <Button variant="primary" onClick={open}>
-                  { coverURL ? __('Change cover', 'luxurybazaar_jewelry') : __('Choose cover', 'luxurybazaar_jewelry') }
+                  {coverURLs.length
+                    ? __('Edit images', 'luxurybazaar_jewelry')
+                    : __('Choose images', 'luxurybazaar_jewelry')}
                 </Button>
               )}
             />
@@ -34,7 +44,27 @@ registerBlockType('lb-jewelry/hero', {
           </PanelBody>
         </InspectorControls>
         <div {...blockProps}>
-          {coverURL && <img className="wpgcb-hero__cover" src={coverURL} alt="" />}
+          {coverURLs.length > 0 && (
+            <Swiper
+              modules={[EffectFade, Autoplay]}
+              effect="fade"
+              slidesPerView={1}
+              allowTouchMove={false}
+              autoplay={{ delay: 4000 }}
+              loop
+              className="wpgcb-hero__slider"
+            >
+              {coverURLs.map((url, index) => (
+                <SwiperSlide key={index}>
+                  <img
+                    className={`wpgcb-hero__cover${index === 0 ? ' wpgcb-hero__cover--first' : ''}`}
+                    src={url}
+                    alt=""
+                  />
+                </SwiperSlide>
+              ))}
+            </Swiper>
+          )}
           <div className="wpgcb-hero__overlay" style={{ opacity: overlayOpacity }} />
           <div className="wpgcb-hero__rect wpgcb-hero__rect--left" />
           <div className="wpgcb-hero__rect wpgcb-hero__rect--right" />
@@ -59,11 +89,25 @@ registerBlockType('lb-jewelry/hero', {
     );
   },
   save: ({ attributes }) => {
-    const { title, subtitle, coverURL, overlayOpacity } = attributes;
+    const { title, subtitle, coverURLs = [], overlayOpacity } = attributes;
     const blockProps = useBlockProps.save({ className: 'wpgcb-hero' });
     return (
       <div {...blockProps}>
-        {coverURL && <img className="wpgcb-hero__cover" src={coverURL} alt="" />}
+        {coverURLs.length > 0 && (
+          <div className="wpgcb-hero__slider swiper">
+            <div className="swiper-wrapper">
+              {coverURLs.map((url, index) => (
+                <div className="swiper-slide" key={index}>
+                  <img
+                    className={`wpgcb-hero__cover${index === 0 ? ' wpgcb-hero__cover--first' : ''}`}
+                    src={url}
+                    alt=""
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
         <div className="wpgcb-hero__overlay" style={{ opacity: overlayOpacity }} />
         <div className="wpgcb-hero__rect wpgcb-hero__rect--left" />
         <div className="wpgcb-hero__rect wpgcb-hero__rect--right" />

--- a/src/blocks/hero/style.css
+++ b/src/blocks/hero/style.css
@@ -7,3 +7,7 @@
 .wpgcb-hero__content { position:relative; z-index:3; max-width:900px; }
 .wpgcb-hero__title { margin:0 0 1rem; color:#fff; font-family:Cardo; font-size:80px; font-style:normal; font-weight:700; line-height:88px; }
 .wpgcb-hero__subtitle { margin:0; color:#fff; font-family:Lato; font-size:24px; font-style:normal; font-weight:700; line-height:26.4px; }
+.wpgcb-hero__slider { position:absolute; inset:0; }
+.wpgcb-hero .swiper-slide { position:relative; width:100%; height:100%; }
+.wpgcb-hero__cover--first { transform:scale(1.1); animation:wpgcb-hero-zoom .5s ease-out forwards; }
+@keyframes wpgcb-hero-zoom { to { transform:scale(1); } }

--- a/src/blocks/hero/view.js
+++ b/src/blocks/hero/view.js
@@ -1,0 +1,25 @@
+import Swiper from 'swiper';
+import { EffectFade, Autoplay } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/effect-fade';
+
+function initHero() {
+  document.querySelectorAll('.wpgcb-hero__slider').forEach((el) => {
+    if (el.dataset.initialized === 'true') return;
+    new Swiper(el, {
+      modules: [EffectFade, Autoplay],
+      effect: 'fade',
+      loop: true,
+      allowTouchMove: false,
+      autoplay: { delay: 4000 },
+      fadeEffect: { crossFade: true },
+    });
+    el.dataset.initialized = 'true';
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initHero);
+} else {
+  initHero();
+}


### PR DESCRIPTION
## Summary
- allow hero block to display multiple images in a swiper carousel
- add front-end script and styles for fade/zoom animations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de754ac6483268e0bab789231d977