### PR TITLE
Add server logging to carousel block

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,3 +26,23 @@ function lb_jewelry_register_blocks() {
     register_block_type( __DIR__ . '/build/blocks/image-banner' );
 }
 add_action( 'init', 'lb_jewelry_register_blocks' );
+
+/**
+ * Simple REST endpoint for logging debug messages.
+ */
+function lbj_debug_log( WP_REST_Request $request ) {
+    $message   = $request->get_param( 'message' );
+    $timestamp = current_time( 'mysql' );
+    $line      = '[' . $timestamp . '] ' . $message . PHP_EOL;
+    $file      = '/var/www/debug.log';
+    file_put_contents( $file, $line, FILE_APPEND );
+    return rest_ensure_response( array( 'logged' => true ) );
+}
+
+add_action( 'rest_api_init', function() {
+    register_rest_route( 'lb-jewelry/v1', '/log', array(
+        'methods'             => 'POST',
+        'callback'            => 'lbj_debug_log',
+        'permission_callback' => '__return_true',
+    ) );
+} );

--- a/src/blocks/carousel/index.js
+++ b/src/blocks/carousel/index.js
@@ -62,6 +62,19 @@ function getBrand(product) {
   return '';
 }
 
+// Send debug logs to server
+function log(message) {
+  try {
+    fetch('/wp-json/lb-jewelry/v1/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    });
+  } catch (e) {
+    // fail silently
+  }
+}
+
 registerBlockType('lb-jewelry/carousel', {
   edit: ({ attributes, setAttributes }) => {
     const {
@@ -81,10 +94,22 @@ registerBlockType('lb-jewelry/carousel', {
         '?attributes[0][attribute]=pa_product_type' +
         '&attributes[0][slug]=jewelry' +
         '&per_page=10';
+      log(`Editor carousel: fetching ${url}`);
       fetch(url)
         .then((res) => res.json())
-        .then((data) => (Array.isArray(data) ? setProducts(data) : setProducts([])))
-        .catch(() => setProducts([]));
+        .then((data) => {
+          if (Array.isArray(data)) {
+            log(`Editor carousel: received ${data.length} products`);
+            setProducts(data);
+          } else {
+            log('Editor carousel: invalid products response');
+            setProducts([]);
+          }
+        })
+        .catch((err) => {
+          log(`Editor carousel: fetch error ${err}`);
+          setProducts([]);
+        });
     }, [mode]);
 
     const addSlide = () =>

--- a/src/blocks/carousel/view.js
+++ b/src/blocks/carousel/view.js
@@ -35,17 +35,33 @@ function getBrand(product) {
   return '';
 }
 
+// Send debug logs to server
+function log(message) {
+  try {
+    fetch('/wp-json/lb-jewelry/v1/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    });
+  } catch (e) {
+    // fail silently
+  }
+}
+
 function initCarousels() {
   document.querySelectorAll('.wpgcb-carousel').forEach((el, index) => {
     if (el.dataset.initialized === 'true') return;
+    log(`Carousel ${index}: start initialization`);
 
     const autoplay = el.dataset.autoplay === 'true';
     const loop = el.dataset.loop === 'true';
     const mode = el.dataset.mode || 'latest';
+    log(`Carousel ${index}: mode=${mode}`);
 
     const swiperEl = el.querySelector('.swiper');
     const wrapper  = el.querySelector('.swiper-wrapper');
     const hasSlides = wrapper && wrapper.children.length > 0;
+    log(`Carousel ${index}: hasSlides=${hasSlides}`);
 
     // Guards to prevent bad init
     if (!(swiperEl instanceof Element) || !(wrapper instanceof Element)) {
@@ -98,11 +114,16 @@ function initCarousels() {
         '?attributes[0][attribute]=pa_product_type' +
         '&attributes[0][slug]=jewelry' +
         '&per_page=10';
+      log(`Carousel ${index}: fetching ${url}`);
 
       fetch(url)
         .then((res) => res.json())
         .then((products) => {
-          if (!Array.isArray(products) || !(wrapper instanceof Element)) return;
+          if (!Array.isArray(products) || !(wrapper instanceof Element)) {
+            log(`Carousel ${index}: invalid products response`);
+            return;
+          }
+          log(`Carousel ${index}: received ${products.length} products`);
           wrapper.innerHTML = '';
 
           products.forEach((product) => {
@@ -134,10 +155,14 @@ function initCarousels() {
           });
 
           initSwiper();
+          log(`Carousel ${index}: swiper initialized after fetch`);
         })
-        .catch(() => {});
+        .catch((err) => {
+          log(`Carousel ${index}: fetch error ${err}`);
+        });
     } else if (hasSlides) {
       initSwiper();
+      log(`Carousel ${index}: swiper initialized with existing slides`);
     }
   });
 }


### PR DESCRIPTION
## Summary
- expose `/lb-jewelry/v1/log` REST endpoint to write debug messages to `/var/www/debug.log`
- instrument carousel block scripts to send detailed progress logs

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6d57ab5288326857d807fce7332b1